### PR TITLE
Deprecate React Router and use Next.js Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/1cfad40e-8283-4490-a220-2b66ad254c7d/deploy-status)](https://app.netlify.com/sites/kelbyhawn/deploys)
 
-👩🏻‍💻 My site! 
+👩🏻‍💻 My site!
 
 [kelbyhawn.com](https://kelbyhawn.com)
 
 Includes links to:
+
 - Side projects (which you can find here on [GitHub](https://github.com/kelbyhawn))
 - [CodePen](https://codepen.io/kelbyhawn)
 
@@ -14,6 +15,4 @@ Includes links to:
 
 - [React](https://reactjs.org/) - A declarative, efficient, and flexible JavaScript library for building user interfaces.
 - [Next.js](https://nextjs.org/) - The React framework for the web.
-- [React Router](https://www.npmjs.com/package/react-router) - A user‑obsessed, standards‑focused, multi‑strategy router you can deploy anywhere.
-- [React Router Hash Link](https://github.com/rafgraph/react-router-hash-link) - Solution for React Router not scrolling to hash links.
 - [Sass](https://sass-lang.com) - CSS with superpowers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "next": "^16.2.12",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.2.1",
-        "react-router-hash-link": "^2.4.3",
         "sass": "^1.49.0"
       },
       "devDependencies": {
@@ -235,15 +233,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3882,14 +3871,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/history": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
-      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4819,6 +4800,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5086,6 +5068,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5095,7 +5078,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5151,42 +5135,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
-      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
-      "dependencies": {
-        "history": "^5.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
-      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
-      "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-hash-link": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
-      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=15",
-        "react-router-dom": ">=4"
       }
     },
     "node_modules/readdirp": {
@@ -6469,11 +6417,6 @@
       "requires": {
         "@babel/types": "^7.29.7"
       }
-    },
-    "@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
     },
     "@babel/template": {
       "version": "7.29.7",
@@ -8620,14 +8563,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "history": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
-      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9191,7 +9126,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.13.4",
@@ -9363,6 +9299,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9372,7 +9309,8 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
         }
       }
     },
@@ -9403,31 +9341,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
-      }
-    },
-    "react-router": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
-      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
-      "requires": {
-        "history": "^5.2.0"
-      }
-    },
-    "react-router-dom": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
-      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
-      "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.2.1"
-      }
-    },
-    "react-router-hash-link": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
-      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
-      "requires": {
-        "prop-types": "^15.7.2"
       }
     },
     "readdirp": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "next": "^16.2.12",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.2.1",
-    "react-router-hash-link": "^2.4.3",
     "sass": "^1.49.0"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,27 +1,8 @@
-// Dependencies
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate,
-} from "react-router-dom";
-
-// Assets
-import "./styles/reset.css";
-import "./styles/App.sass";
-
-// Layout Component
+// Container Component
 import Container from "./Container";
 
 function App() {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Container />} />
-        <Route path="*" element={<Navigate to="/" />} />
-      </Routes>
-    </Router>
-  );
+  return <Container />;
 }
 
 export default App;

--- a/src/Container.js
+++ b/src/Container.js
@@ -1,12 +1,7 @@
-// Dependencies
-import { Link } from "react-router-dom";
-import { HashLink } from "react-router-hash-link";
-
 // Components
 import Header from "./sections/Header";
 import Footer from "./sections/Footer";
 import Main from "./sections/Main";
-import Hyperlink from "./components/Hyperlink";
 
 export default function Layout() {
   return (

--- a/src/Container.js
+++ b/src/Container.js
@@ -3,7 +3,7 @@ import Header from "./sections/Header";
 import Footer from "./sections/Footer";
 import Main from "./sections/Main";
 
-export default function Layout() {
+export default function Container() {
   return (
     <>
       <Header />

--- a/src/components/Hyperlink.js
+++ b/src/components/Hyperlink.js
@@ -1,7 +1,0 @@
-export default function Hyperlink({ href, linkText, className }) {
-  return (
-    <a href={href} target="_blank" rel="noreferrer" className={className}>
-      {linkText}
-    </a>
-  );
-}

--- a/src/components/SideProject.js
+++ b/src/components/SideProject.js
@@ -1,5 +1,5 @@
 // Components
-import Hyperlink from "./Hyperlink";
+import Link from "next/link";
 
 export default function SideProject({
   description,
@@ -9,7 +9,9 @@ export default function SideProject({
 }) {
   return (
     <div>
-      <Hyperlink href={href} linkText={linkText} className={className} />
+      <Link href={href} className={className}>
+        {linkText}
+      </Link>
       <p>{description}</p>
     </div>
   );

--- a/src/components/SideProject.js
+++ b/src/components/SideProject.js
@@ -9,7 +9,7 @@ export default function SideProject({
 }) {
   return (
     <div>
-      <Link href={href} className={className}>
+      <Link href={href} className={className} target="_blank">
         {linkText}
       </Link>
       <p>{description}</p>

--- a/src/sections/Footer.js
+++ b/src/sections/Footer.js
@@ -8,8 +8,13 @@ export default function Footer() {
     <footer>
       <p>
         ©{year} <small>Kelby Hawn</small> <span>•</span>{" "}
-        <Link href="https://www.linkedin.com/in/kelby-hawn/">LinkedIn</Link>{" "}
-        <span>•</span> <Link href="https://github.com/kelbyhawn">GitHub</Link>
+        <Link href="https://www.linkedin.com/in/kelby-hawn/" target="_blank">
+          LinkedIn
+        </Link>{" "}
+        <span>•</span>{" "}
+        <Link href="https://github.com/kelbyhawn" target="_blank">
+          GitHub
+        </Link>
       </p>
     </footer>
   );

--- a/src/sections/Footer.js
+++ b/src/sections/Footer.js
@@ -1,5 +1,5 @@
 // Components
-import Hyperlink from "../components/Hyperlink";
+import Link from "next/link";
 
 export default function Footer() {
   const year = new Date().getFullYear();
@@ -8,12 +8,8 @@ export default function Footer() {
     <footer>
       <p>
         ©{year} <small>Kelby Hawn</small> <span>•</span>{" "}
-        <Hyperlink
-          href="https://www.linkedin.com/in/kelby-hawn/"
-          linkText="LinkedIn"
-        />{" "}
-        <span>•</span>{" "}
-        <Hyperlink href="https://github.com/kelbyhawn" linkText="GitHub" />
+        <Link href="https://www.linkedin.com/in/kelby-hawn/">LinkedIn</Link>{" "}
+        <span>•</span> <Link href="https://github.com/kelbyhawn">GitHub</Link>
       </p>
     </footer>
   );

--- a/src/sections/Header.js
+++ b/src/sections/Header.js
@@ -1,10 +1,6 @@
-// Dependencies
-import { Link } from "react-router-dom";
-import { HashLink } from "react-router-hash-link";
-
 // Components
-import Hyperlink from "../components/Hyperlink";
 import Image from "next/image";
+import Link from "next/link";
 
 // Assets
 import logo from "../assets/kh-logo.svg";
@@ -12,7 +8,7 @@ import logo from "../assets/kh-logo.svg";
 export default function Header() {
   return (
     <header>
-      <Link to="/">
+      <Link href="/">
         <Image
           src={logo}
           alt="Kelby Hawn logo"
@@ -24,16 +20,14 @@ export default function Header() {
       <nav>
         <ul>
           <li>
-            <HashLink smooth to="#side-projects" className="light">
+            <Link href="#side-projects" className="light">
               Projects
-            </HashLink>
+            </Link>
           </li>
           <li>
-            <Hyperlink
-              href="https://github.com/kelbyhawn"
-              className="light"
-              linkText="GitHub"
-            />
+            <Link href="https://github.com/kelbyhawn" className="light">
+              GitHub
+            </Link>
           </li>
         </ul>
       </nav>

--- a/src/sections/Header.js
+++ b/src/sections/Header.js
@@ -25,7 +25,11 @@ export default function Header() {
             </Link>
           </li>
           <li>
-            <Link href="https://github.com/kelbyhawn" className="light">
+            <Link
+              href="https://github.com/kelbyhawn"
+              className="light"
+              target="_blank"
+            >
               GitHub
             </Link>
           </li>

--- a/src/sections/Main.js
+++ b/src/sections/Main.js
@@ -1,3 +1,4 @@
+// Components
 import Top from "./Top";
 import Projects from "./Projects";
 

--- a/src/sections/Top.js
+++ b/src/sections/Top.js
@@ -10,17 +10,21 @@ export default function Top() {
 
       <p>
         ✨{" "}
-        <Link href="https://www.linkedin.com/in/kelby-hawn/" className="light">
+        <Link
+          href="https://www.linkedin.com/in/kelby-hawn/"
+          className="light"
+          target="_blank"
+        >
           Open to work
         </Link>
       </p>
       <p className="past-work">
         Previously at{" "}
-        <Link href="https://code.org" className="light">
+        <Link href="https://code.org" className="light" target="_blank">
           Code.org
         </Link>{" "}
         • Co-founder at{" "}
-        <Link href="https://dolly.com" className="light">
+        <Link href="https://dolly.com" className="light" target="_blank">
           Dolly
         </Link>
       </p>

--- a/src/sections/Top.js
+++ b/src/sections/Top.js
@@ -1,5 +1,5 @@
 // Components
-import Hyperlink from "../components/Hyperlink";
+import Link from "next/link";
 
 export default function Top() {
   return (
@@ -10,25 +10,19 @@ export default function Top() {
 
       <p>
         ✨{" "}
-        <Hyperlink
-          href="https://www.linkedin.com/in/kelby-hawn/"
-          linkText="Open to work"
-          className="light"
-        />
+        <Link href="https://www.linkedin.com/in/kelby-hawn/" className="light">
+          Open to work
+        </Link>
       </p>
       <p className="past-work">
         Previously at{" "}
-        <Hyperlink
-          href="https://code.org"
-          linkText="Code.org"
-          className="light"
-        />{" "}
+        <Link href="https://code.org" className="light">
+          Code.org
+        </Link>{" "}
         • Co-founder at{" "}
-        <Hyperlink
-          href="https://dolly.com"
-          linkText="Dolly"
-          className="light"
-        />
+        <Link href="https://dolly.com" className="light">
+          Dolly
+        </Link>
       </p>
     </section>
   );

--- a/src/styles/App.sass
+++ b/src/styles/App.sass
@@ -3,6 +3,8 @@
 @use 'animation'
 
 //------------------------------------------
+html
+  scroll-behavior: smooth
 
 body
   background-color: #fff


### PR DESCRIPTION
Replaces `react-router-dom` and `react-router-hash-link` with Next.js's built-in Link component. It also removes the custom `Hyperlink` component in favor of using Link for all internal and external links. Additionally, smooth scrolling is enabled globally via CSS. These changes simplify the codebase and improve compatibility with Next.js conventions.